### PR TITLE
update rancher's swagger version?

### DIFF
--- a/docs/modules/ROOT/pages/rancher-api.adoc
+++ b/docs/modules/ROOT/pages/rancher-api.adoc
@@ -2,7 +2,7 @@
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>
-        Redoc.init('./_attachments/swagger.json',
+        Redoc.init('./_attachments/v1.3-swagger.json',
         {scrollYOffset: '.toolbar'},
         document.getElementById('redoc-container'))
     </script>


### PR DESCRIPTION
When I previewed the demo site, I noticed that there was text overlap on the Rancher API page, but not on the Harvester page:

![image](https://github.com/sunilarjun/antora-rancher-docs-api/assets/19174201/efb138b8-2c3e-4e80-9766-ad217c3199af)

Updating the swagger version in rancher-api.adoc appears to fix this. 